### PR TITLE
feat: add search with Pagefind (without FAQs)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
           pip install -U pip
           pip install "Lektor>=3.3.4"
+          pip install "pagefind[extended]"
           pip freeze
       - name: Deploy
         env:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ the following command and open
 $ lektor server
 ```
 
+#### Documentation search with Pagefind
+
+In order to test the documentation search functionality, install the `pagefind[extended]` package and run the following commands:
+
+```console
+$ lektor build
+$ python -m pagefind --site "$(lektor project-info --output-path)" --serve
+```
+
 ### Contributing
 
 Contributions are welcome, and they are greatly appreciated! Every little bit

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -170,3 +170,12 @@ summary {
 .docs-blocks h3 {
   margin-top: 50px;
 }
+
+:root {
+  /*
+  Making the max-width of the Pagefind searchbox wide enough,
+  so that it fits the full width of its parent container.
+  See: https://pagefind.app/docs/css-variables/
+  */
+  --pf-searchbox-max-width: 800px !important;
+}

--- a/content/help/contents.lr
+++ b/content/help/contents.lr
@@ -76,6 +76,17 @@ body:
 title: Docs
 ----
 body:
+
+<div class="row" style="margin-bottom:20px;">
+    <div class="col-md-3"></div>
+    <div class="col-md-6 text-center">
+
+        <pagefind-searchbox placeholder="Search Docs and Guides...">Search widget</pagefind-searchbox>
+
+    </div>
+    <div class="col-md-3"></div>
+</div>
+
 ----
 menu: /help/docs
 

--- a/rundeploy.sh
+++ b/rundeploy.sh
@@ -41,6 +41,7 @@ ssh-add -D
 ssh-add - <<< "${HELP_SSH_PRIVATE_KEY}"
 lektor clean --yes
 lektor build
+python -m pagefind --site "$(lektor project-info --output-path)"
 ls -l
 lektor deploy ghpageshelp
 rm content

--- a/templates/base.html
+++ b/templates/base.html
@@ -50,10 +50,12 @@
 <link rel="stylesheet" href="{{ '/static/zenodo.css'|url }}">
 <link rel="stylesheet" href="{{ '/static/style.css'|url }}">
 <link rel="stylesheet" href="{{ '/static/font-awesome/css/font-awesome.min.css'|url}}">
+<link rel="stylesheet" href="{{ '/pagefind/pagefind-component-ui.css'|url}}">
 <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,100,italic" rel="stylesheet">
 <title>{% block title %}{% endblock %}{% if self.title() %} | {% endif %}Zenodo</title>
 <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+<script src="{{ '/pagefind/pagefind-component-ui.js'|url}}" type="module"></script>
 </head>
 <body>
   <header>

--- a/templates/docspage.html
+++ b/templates/docspage.html
@@ -51,7 +51,7 @@
     </div>
     <div class="col-md-8">
       {{ render_breadcrumb(this, root=site.get(breadcrumb_root)) }}
-      <div class="docs-blocks">
+      <div class="docs-blocks" data-pagefind-body>
       <h1>{{this.title}}</h1>
       {%if this.lead%}
       <h2><small>{{this.lead}}</small></h2>{% endif%}


### PR DESCRIPTION
Adds a post-build step with [Pagefind](https://pagefind.app/) to add search functionality to the Docs and Guides pages.
Alternative more complex PR also including search for the FAQs: #167 

Place of the widget on the page:
<img width="1005" height="1061" alt="Screenshot of the Pagefind searchbox on the Zenodo help documention" src="https://github.com/user-attachments/assets/96e0f6d4-2dab-4894-8f6e-50f01ea495fa" />

Search results:
<img width="1004" height="436" alt="Pagefind searchbox search results" src="https://github.com/user-attachments/assets/78cfe2cb-4607-4c52-b95b-1bc96c250ed7" />