### PR TITLE
feat: add search with Pagefind (with FAQs)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           pip install -U pip
           pip install "Lektor>=3.3.4"
+          pip install "pagefind[extended]"
+          pip install beautifulsoup4
           pip freeze
       - name: Deploy
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
           pip install "Lektor>=3.3.4"
           pip install "pagefind[extended]"
           pip install beautifulsoup4
+          pip install requests
           pip freeze
       - name: Deploy
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 dist
 venv
 lektor/admin/static/gen
+.zammad-cache.json
 
 node_modules
 gui/build

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ the following command and open
 $ lektor server
 ```
 
+#### Documentation search with Pagefind
+
+In order to test the documentation search functionality, install the `pagefind[extended]` and `beautifulsoup4` packages and run the following commands:
+
+```console
+$ lektor build
+$ python pagefind_index.py "$(lektor project-info --output-path)"
+$ python -m http.server --directory "$(lektor project-info --output-path)"
+```
+
 ### Contributing
 
 Contributions are welcome, and they are greatly appreciated! Every little bit

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ lektor server
 
 #### Documentation search with Pagefind
 
-In order to test the documentation search functionality, install the `pagefind[extended]` and `beautifulsoup4` packages and run the following commands:
+In order to test the documentation search functionality, install the `pagefind[extended]`, `beautifulsoup4` and `requests` packages and run the following commands:
 
 ```console
 $ lektor build

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -170,3 +170,12 @@ summary {
 .docs-blocks h3 {
   margin-top: 50px;
 }
+
+:root {
+  /*
+  Making the max-width of the Pagefind searchbox wide enough,
+  so that it fits the full width of its parent container.
+  See: https://pagefind.app/docs/css-variables/
+  */
+  --pf-searchbox-max-width: 800px !important;
+}

--- a/content/help/contents.lr
+++ b/content/help/contents.lr
@@ -8,7 +8,15 @@ sort_key: 1
 ---
 body:
 
-# Help with Zenodo
+<div class="row" style="margin-bottom:20px;">
+    <div class="col-md-3"></div>
+    <div class="col-md-6 text-center">
+
+        <pagefind-searchbox>Search widget</pagefind-searchbox>
+
+    </div>
+    <div class="col-md-3"></div>
+</div>
 
 ---
 sections:
@@ -17,17 +25,6 @@ sections:
 title: Frequently Asked Questions
 ----
 body:
-
-
-<div class="row" style="margin-bottom:20px;">
-    <div class="col-md-3"></div>
-    <div class="col-md-6">
-
-        <h4 class="text-center"><a href="https://support.zenodo.org/help/">Search FAQ</a></h4>
-
-    </div>
-    <div class="col-md-3"></div>
-</div>
 
 <div class="row">
     <div class="col-md-3">

--- a/content/help/docs/contents.lr
+++ b/content/help/docs/contents.lr
@@ -8,7 +8,15 @@ sort_key: 1
 ---
 body:
 
-# Help with Zenodo
+<div class="row" style="margin-bottom:20px;">
+    <div class="col-md-3"></div>
+    <div class="col-md-6 text-center">
+
+        <pagefind-searchbox>Search widget</pagefind-searchbox>
+
+    </div>
+    <div class="col-md-3"></div>
+</div>
 
 ---
 sections:

--- a/content/help/faq/contents.lr
+++ b/content/help/faq/contents.lr
@@ -8,19 +8,18 @@ faqlist:
 ---
 toptext:
 
-# Frequently Asked Questions
-<hr />
-
-
 <div class="row" style="margin-bottom:20px;">
     <div class="col-md-3"></div>
-    <div class="col-md-6">
+    <div class="col-md-6 text-center">
 
-        <h4 class="text-center"><a href="https://support.zenodo.org/help/">Search FAQ</a></h4>
+        <pagefind-searchbox>Search widget</pagefind-searchbox>
 
     </div>
     <div class="col-md-3"></div>
 </div>
+
+# Frequently Asked Questions
+<hr />
 
 <div class="row">
     <div class="col-md-3">

--- a/content/help/guides/contents.lr
+++ b/content/help/guides/contents.lr
@@ -6,7 +6,15 @@ lead: Learn Zenodo through guides
 ---
 body:
 
-# Help with Zenodo
+<div class="row" style="margin-bottom:20px;">
+    <div class="col-md-3"></div>
+    <div class="col-md-6 text-center">
+
+        <pagefind-searchbox>Search widget</pagefind-searchbox>
+
+    </div>
+    <div class="col-md-3"></div>
+</div>
 
 ---
 sections:

--- a/pagefind_index.py
+++ b/pagefind_index.py
@@ -1,0 +1,106 @@
+import asyncio
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+from pagefind.index import IndexConfig, PagefindIndex
+
+BASE_URL = "https://support.zenodo.org/help/"
+CACHE_FILENAME = ".zammad-cache.json"
+
+
+def fetch(url):
+    time.sleep(0.5)
+    content = requests.get(url).text
+    return BeautifulSoup(content, "html.parser")
+
+
+def scrape_zammad_answer(url, answers):
+    print(f"Scraping answer: {url}")
+    soup = fetch(url)
+
+    soup_body = soup.select_one("main article .container")
+    # Setting the attribute to `None` is the way to have the attribute added but without a value.
+    soup_body["data-pagefind-body"] = None
+
+    answer_soup_meta = soup_body.select_one(".article-meta")
+    answer_soup_meta["data-pagefind-ignore"] = None
+
+    answers.append(
+        {
+            "content": str(soup),
+            "url": url,
+        }
+    )
+
+
+def scrape_zammad_category(url, answers):
+    print(f"Scraping category: {url}")
+    soup = fetch(url)
+
+    for category_link in soup.select(".sections--grid li.section a"):
+        category_url = urljoin(BASE_URL, category_link["href"])
+        scrape_zammad_category(category_url, answers)
+
+    for answer_link in soup.select(".sections--list li.section a"):
+        answer_url = urljoin(BASE_URL, answer_link["href"])
+        scrape_zammad_answer(answer_url, answers)
+
+
+def scrape_zammad():
+    cache_path = Path(CACHE_FILENAME)
+    if (
+        cache_path.is_file()
+        and datetime.fromtimestamp(cache_path.stat().st_mtime).date()
+        == datetime.today().date()
+    ):
+        print("Using cache file modified today...")
+        answers = json.loads(cache_path.read_text())
+    else:
+        answers = []
+        scrape_zammad_category(BASE_URL, answers)
+        cache_path.write_text(json.dumps(answers))
+    return answers
+
+
+async def main(path):
+    print("Scraping...")
+    zammad_answers = scrape_zammad()
+
+    print("Indexing...")
+    config = IndexConfig(
+        output_path=os.path.join(path, "pagefind"),
+        force_language="en",
+    )
+    async with PagefindIndex(config=config) as index:
+        # Index the output of the static site.
+        tasks = [index.add_directory(path)]
+
+        # Index the Zammad answers.
+        for answer in zammad_answers:
+            tasks.append(
+                index.add_html_file(
+                    content=answer["content"],
+                    url=answer["url"],
+                )
+            )
+
+        await asyncio.gather(*tasks)
+
+    print("Done")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python pagefind_index.py path")
+        sys.exit(1)
+
+    path = sys.argv[1]
+
+    asyncio.run(main(path))

--- a/pagefind_index.py
+++ b/pagefind_index.py
@@ -30,7 +30,7 @@ def scrape_zammad_answer(url, answers):
         # Setting the attribute to `None` is the way to have the attribute added but without a value.
         soup_body["data-pagefind-body"] = None
 
-        soup_meta = soup_body.select_one(".article-metaz")
+        soup_meta = soup_body.select_one(".article-meta")
         if soup_meta:
             soup_meta["data-pagefind-ignore"] = None
         else:

--- a/pagefind_index.py
+++ b/pagefind_index.py
@@ -26,11 +26,19 @@ def scrape_zammad_answer(url, answers):
     soup = fetch(url)
 
     soup_body = soup.select_one("main article .container")
-    # Setting the attribute to `None` is the way to have the attribute added but without a value.
-    soup_body["data-pagefind-body"] = None
+    if soup_body:
+        # Setting the attribute to `None` is the way to have the attribute added but without a value.
+        soup_body["data-pagefind-body"] = None
 
-    answer_soup_meta = soup_body.select_one(".article-meta")
-    answer_soup_meta["data-pagefind-ignore"] = None
+        soup_meta = soup_body.select_one(".article-metaz")
+        if soup_meta:
+            soup_meta["data-pagefind-ignore"] = None
+        else:
+            print(
+                "Answer metadata cannot be found, the metadata will not be excluded from indexing"
+            )
+    else:
+        print("Answer body cannot be found, all the page content will be indexed")
 
     answers.append(
         {

--- a/rundeploy.sh
+++ b/rundeploy.sh
@@ -41,6 +41,7 @@ ssh-add -D
 ssh-add - <<< "${HELP_SSH_PRIVATE_KEY}"
 lektor clean --yes
 lektor build
+python pagefind_index.py "$(lektor project-info --output-path)"
 ls -l
 lektor deploy ghpageshelp
 rm content

--- a/templates/base.html
+++ b/templates/base.html
@@ -50,10 +50,12 @@
 <link rel="stylesheet" href="{{ '/static/zenodo.css'|url }}">
 <link rel="stylesheet" href="{{ '/static/style.css'|url }}">
 <link rel="stylesheet" href="{{ '/static/font-awesome/css/font-awesome.min.css'|url}}">
+<link rel="stylesheet" href="{{ '/pagefind/pagefind-component-ui.css'|url}}">
 <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,100,italic" rel="stylesheet">
 <title>{% block title %}{% endblock %}{% if self.title() %} | {% endif %}Zenodo</title>
 <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+<script src="{{ '/pagefind/pagefind-component-ui.js'|url}}" type="module"></script>
 </head>
 <body>
   <header>

--- a/templates/docsindex.html
+++ b/templates/docsindex.html
@@ -30,6 +30,7 @@
 {% endblock %}
 {% block title %}{{ this.title }}{% endblock %}
 {% block body %}
+{{ this.body }}
 
 {% for block in this.sections.blocks %}
 {{block}}

--- a/templates/docspage.html
+++ b/templates/docspage.html
@@ -51,7 +51,7 @@
     </div>
     <div class="col-md-8">
       {{ render_breadcrumb(this, root=site.get(breadcrumb_root)) }}
-      <div class="docs-blocks">
+      <div class="docs-blocks" data-pagefind-body>
       <h1>{{this.title}}</h1>
       {%if this.lead%}
       <h2><small>{{this.lead}}</small></h2>{% endif%}


### PR DESCRIPTION
Adds a post-build step with [Pagefind](https://pagefind.app/) to add search functionality to the Docs and Guides pages, as well as the Zammad FAQs by scraping it and caching results for one day.
Alternative simpler PR not including search for the FAQs: #166

Place of the widget on the page:
<img width="1041" height="767" alt="Screenshot of the Pagefind searchbox on the Zenodo help documention" src="https://github.com/user-attachments/assets/1084b205-2a97-4b54-a356-c9d57eaa3c5f" />

Search results including content for the FAQs and the Docs:
<img width="493" height="411" alt="Pagefind searchbox search results" src="https://github.com/user-attachments/assets/49228529-e435-4da3-838a-ab130db4452f" />
